### PR TITLE
WIP Updated color of diff editor into eye-friendly.

### DIFF
--- a/themes/Actual Xcode Dark Theme-color-theme.json
+++ b/themes/Actual Xcode Dark Theme-color-theme.json
@@ -105,11 +105,14 @@
     "editorGutter.addedBackground": "#4dbf57",
     "editorGutter.deletedBackground": "#e21515",
 
-    "diffEditor.insertedTextBackground": "#ff0000",
-    "diffEditor.insertedTextBorder": "#ff0000",
-    "diffEditor.removedTextBackground": "#ff0000",
+    "diffEditor.insertedTextBackground": "#5bb6ff60",
+    "diffEditor.insertedTextBorder": "#5bb6ff60",
+    "diffEditor.removedTextBackground": "#ff000040",
     "diffEditor.removedTextBorder": "#ff0000",
-    "diffEditor.border": "#ff0000",
+    "diffEditor.border": "#ff000040",
+    "diffEditor.diagonalFill": "#aad4ff55",
+    "diffEditor.border": "#ff000050",
+
 
     "panel.background": "#1e1e1e",
     "panel.border": "#00000000",

--- a/themes/Actual Xcode Dark Theme-color-theme.json
+++ b/themes/Actual Xcode Dark Theme-color-theme.json
@@ -108,10 +108,9 @@
     "diffEditor.insertedTextBackground": "#5bb6ff60",
     "diffEditor.insertedTextBorder": "#5bb6ff60",
     "diffEditor.removedTextBackground": "#ff000040",
-    "diffEditor.removedTextBorder": "#ff0000",
+    "diffEditor.removedTextBorder": "#ff000040",
     "diffEditor.border": "#ff000040",
     "diffEditor.diagonalFill": "#aad4ff55",
-    "diffEditor.border": "#ff000050",
 
 
     "panel.background": "#1e1e1e",

--- a/themes/Actual Xcode Dark Theme-color-theme.json
+++ b/themes/Actual Xcode Dark Theme-color-theme.json
@@ -7,11 +7,11 @@
     "descriptionForeground": "#ffffff",
     "errorForeground": "#ece1e0",
 
-    "textBlockQuote.background": "#ff0000",
-    "textBlockQuote.border": "#ff0000",
-    "textCodeBlock.background": "#ff0000",
-    "textLink.activeForeground": "#6699fe",
-    "textLink.foreground": "#6699fe",
+    "textBlockQuote.background": "#ffffff",
+    "textBlockQuote.border": "#ffffff",
+    "textCodeBlock.background": "#595959",
+    "textLink.activeForeground": "#E5E5E5",
+    "textLink.foreground": "#E5E5E5",
     "textPreformat.foreground": "#ffffffd8",
     "textSeparator.foreground": "#ffffffd8",
 
@@ -30,7 +30,7 @@
     "scrollbarSlider.hoverBackground": "#ffffff8F",
 
     "activityBar.background": "#2d2d2d",
-    "activityBar.dropBackground": "#555555",
+    "activityBar.dropBorder": "#555555",
     "activityBar.border": "#00000000",
     "activityBar.foreground": "#ffffff",
     "activityBar.inactiveForeground": "#ffffff8F",
@@ -114,8 +114,8 @@
 
 
     "panel.background": "#1e1e1e",
-    "panel.border": "#00000000",
-    "panel.dropBackground": "#555555",
+    "panel.border": "#3a3a3a20",
+    "panel.dropBorder": "#555555",
     "panelTitle.activeBorder": "#ff000000",
     "panelTitle.activeForeground": "#ffffff",
     "panelTitle.inactiveForeground": "#ffffff8F",


### PR DESCRIPTION
I like this theme, but I think the color of diff editor is too difficult to see.
    <img width="1400" alt="image" src="https://user-images.githubusercontent.com/16385352/96830730-d9573680-1476-11eb-88d9-8884c35d5dc4.png">



So I chose the color of diff editor of Xcode 12.
(I used [Color Calculator](https://www.colorhexa.com/) to subtract `#292A30`(Xcode editor base color) and `#324460`(Xcode diff highlight color on editor base color) )
    <img width="735" alt="image" src="https://user-images.githubusercontent.com/16385352/96830836-00156d00-1477-11eb-8e95-d2a6a73a8107.png">
